### PR TITLE
Improve database layer and add basic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 App de escritorio en Python (Tkinter + SQLite) para sugerirte actividades/hobbies aleatorios según tus gustos. Sigue el patrón Clean Architecture.
 
+## Uso rápido
+
+1. Instala las dependencias (solo `tk` es necesaria).
+2. Ejecuta `python reset_db.py` para inicializar la base de datos.
+3. Lanza la aplicación con `python main.pyw`.
+
 ## Estructura
 - `main.py`: punto de entrada
 - `presentation/`: interfaz con Tkinter

--- a/data/activity_dao.py
+++ b/data/activity_dao.py
@@ -1,75 +1,106 @@
-import sqlite3
-import random
-import os
+"""Data access layer for hobby and subitem persistence."""
 
-DB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "hobbypicker.db"))
-DB_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "hobbypicker.db")
-)
+import os
+import random
+import sqlite3
+
+from infrastructure.db import get_db_path
+
+DB_PATH = get_db_path()
 
 # Ruta de la base de datos utilizada por la aplicación
 # Si la variable de entorno `HOBBYPICKER_DEBUG` está presente se imprime la ruta
 if os.environ.get("HOBBYPICKER_DEBUG"):
     print("🧭 Base de datos en uso:", DB_PATH)
+
 class ActivityDAO:
-    def __init__(self):
-        self.conn = sqlite3.connect(DB_PATH)
+    """High level API for reading and writing hobbies in the database."""
+
+    def __init__(self, db_path: str | None = None):
+        """Create a new DAO instance and ensure required tables exist."""
+        self.db_path = db_path or DB_PATH
+        self.conn = sqlite3.connect(self.db_path)
         self._create_tables()
 
-    def _create_tables(self):
+    def _create_tables(self) -> None:
+        """Create database tables if they do not already exist."""
         c = self.conn.cursor()
-        c.execute("""CREATE TABLE IF NOT EXISTS activities (
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS activities (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         name TEXT UNIQUE,
                         done INTEGER DEFAULT 0,
                         accepted_count INTEGER DEFAULT 0
-                    )""")
-        c.execute("""CREATE TABLE IF NOT EXISTS subitems (
+                    )"""
+        )
+        c.execute(
+            """CREATE TABLE IF NOT EXISTS subitems (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         activity_id INTEGER,
                         name TEXT,
                         FOREIGN KEY (activity_id) REFERENCES activities(id)
-                    )""")
+                    )"""
+        )
         self.conn.commit()
 
     def get_all_activities(self):
+        """Return all registered hobby activities."""
         return self.conn.execute("SELECT id, name FROM activities").fetchall()
 
     def get_subitems_by_activity(self, activity_id):
+        """Return all subitems linked to a hobby."""
         return self.conn.execute(
-            "SELECT id, activity_id, name FROM subitems WHERE activity_id = ?", (activity_id,)
+            "SELECT id, activity_id, name FROM subitems WHERE activity_id = ?",
+            (activity_id,),
         ).fetchall()
 
     def get_random_with_subitems(self):
+        """Return a random activity that has subitems."""
         c = self.conn.cursor()
-        c.execute("""SELECT a.id, a.name FROM activities a
+        c.execute(
+            """SELECT a.id, a.name FROM activities a
                      WHERE a.done = 0 AND EXISTS (
                          SELECT 1 FROM subitems s WHERE s.activity_id = a.id
-                     )""")
+                     )"""
+        )
         options = c.fetchall()
         return random.choice(options) if options else None
 
     def get_random_with_subitems_or_alone(self):
+        """Return a random activity regardless of having subitems."""
         c = self.conn.cursor()
         c.execute("SELECT id, name FROM activities WHERE done = 0")
         options = c.fetchall()
         return random.choice(options) if options else None
 
     def get_least_used_activity(self):
+        """Return an activity that has been accepted the least."""
         c = self.conn.cursor()
-        c.execute("SELECT id, name, accepted_count FROM activities ORDER BY accepted_count ASC")
+        c.execute(
+            "SELECT id, name, accepted_count FROM activities ORDER BY accepted_count ASC"
+        )
         options = c.fetchall()
-        return random.choice([x for x in options if x[2] == options[0][2]]) if options else None
+        return (
+            random.choice([x for x in options if x[2] == options[0][2]])
+            if options
+            else None
+        )
 
     def increment_accepted_count(self, activity_id):
-        self.conn.execute("UPDATE activities SET accepted_count = accepted_count + 1 WHERE id = ?", (activity_id,))
+        """Increase accepted count for a hobby."""
+        self.conn.execute(
+            "UPDATE activities SET accepted_count = accepted_count + 1 WHERE id = ?",
+            (activity_id,),
+        )
         self.conn.commit()
 
     def accept_activity(self, activity_id):
+        """Mark an activity as done."""
         self.conn.execute("UPDATE activities SET done = 1 WHERE id = ?", (activity_id,))
         self.conn.commit()
 
     def insert_activity(self, name):
+        """Insert a new hobby and return its id."""
         c = self.conn.cursor()
         c.execute("INSERT OR IGNORE INTO activities (name) VALUES (?)", (name,))
         self.conn.commit()
@@ -77,21 +108,34 @@ class ActivityDAO:
         return c.fetchone()[0]
 
     def insert_subitem(self, activity_id, name):
-        self.conn.execute("INSERT INTO subitems (activity_id, name) VALUES (?, ?)", (activity_id, name))
+        """Add a subitem to an existing hobby."""
+        self.conn.execute(
+            "INSERT INTO subitems (activity_id, name) VALUES (?, ?)",
+            (activity_id, name),
+        )
         self.conn.commit()
 
     def delete_subitem(self, subitem_id):
+        """Remove a subitem from the database."""
         self.conn.execute("DELETE FROM subitems WHERE id = ?", (subitem_id,))
         self.conn.commit()
 
     def delete_activity(self, activity_id):
+        """Remove an activity and all its subitems."""
         self.conn.execute("DELETE FROM subitems WHERE activity_id = ?", (activity_id,))
         self.conn.execute("DELETE FROM activities WHERE id = ?", (activity_id,))
         self.conn.commit()
 
     def get_all_with_counts(self):
-        return self.conn.execute("SELECT id, name, accepted_count FROM activities").fetchall()
-    
+        """Return all activities along with their accepted counts."""
+        return self.conn.execute(
+            "SELECT id, name, accepted_count FROM activities"
+        ).fetchall()
+
     def update_subitem(self, subitem_id, new_name):
-        self.conn.execute("UPDATE subitems SET name = ? WHERE id = ?", (new_name, subitem_id))
+        """Update the name of a subitem."""
+        self.conn.execute(
+            "UPDATE subitems SET name = ? WHERE id = ?",
+            (new_name, subitem_id),
+        )
         self.conn.commit()

--- a/domain/models.py
+++ b/domain/models.py
@@ -1,1 +1,22 @@
-# Domain models go here
+"""Simple domain models used by the application."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Activity:
+    """A hobby or activity stored in the database."""
+
+    id: int
+    name: str
+    done: int = 0
+    accepted_count: int = 0
+
+
+@dataclass
+class SubItem:
+    """A specific subitem belonging to an ``Activity``."""
+
+    id: int
+    activity_id: int
+    name: str

--- a/infrastructure/db.py
+++ b/infrastructure/db.py
@@ -1,1 +1,29 @@
-# SQLite connection logic
+"""Utility helpers for interacting with the SQLite database."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+
+DEFAULT_DB_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "hobbypicker.db")
+)
+
+
+def get_db_path() -> str:
+    """Return the path to the SQLite database file."""
+
+    return os.environ.get("HOBBYPICKER_DB", DEFAULT_DB_PATH)
+
+
+@contextmanager
+def connect(db_path: str | None = None) -> sqlite3.Connection:
+    """Context manager that yields a SQLite connection and closes it on exit."""
+
+    path = db_path or get_db_path()
+    conn = sqlite3.connect(path)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/reset_db.py
+++ b/reset_db.py
@@ -1,0 +1,21 @@
+"""Utility script to reset the application's database."""
+
+from data.activity_dao import ActivityDAO
+from infrastructure.db import connect
+
+
+def reset_database() -> None:
+    """Drop existing tables and recreate them."""
+    with connect() as conn:
+        c = conn.cursor()
+        c.execute("DROP TABLE IF EXISTS subitems")
+        c.execute("DROP TABLE IF EXISTS activities")
+        conn.commit()
+
+    # Creating a DAO will recreate the tables
+    ActivityDAO()
+
+
+if __name__ == "__main__":
+    reset_database()
+    print("Database reset completed.")


### PR DESCRIPTION
## Summary
- add dataclass models for Activity and SubItem
- refactor ActivityDAO to use infrastructure db path and add docstrings
- create sqlite helpers with context manager
- implement reset_db utility
- document quick usage in README

## Testing
- `python -m py_compile data/activity_dao.py domain/models.py infrastructure/db.py reset_db.py presentation/app.py`
- `python reset_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68794b8a8bec83338203cd8671647d54