### PR TITLE
Adapt UI to screen resolution and wrap long labels

### DIFF
--- a/presentation/app.py
+++ b/presentation/app.py
@@ -1,5 +1,5 @@
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import ttk, messagebox, font
 from functools import partial
 from domain import use_cases
 from presentation.widgets.styles import apply_style
@@ -73,6 +73,21 @@ def start_app() -> None:
         wheel.draw(data)
 
     root.after(100, refresh_wheel)
+
+    def _fit_label(event):
+        """Shrink label font so text fits within its width."""
+        widget = event.widget
+        widget.config(wraplength=widget.winfo_width())
+        if not hasattr(widget, "_dyn_font"):
+            widget._dyn_font = font.Font(font=widget.cget("font"))
+            widget.config(font=widget._dyn_font)
+        fnt = widget._dyn_font
+        words = widget.cget("text").split()
+        longest = max(words, key=len) if words else ""
+        size = fnt.cget("size")
+        while size > 8 and fnt.measure(longest) > widget.winfo_width():
+            size -= 1
+            fnt.configure(size=size)
 
     current_item = {"id": None, "name": None}
 
@@ -152,7 +167,7 @@ def start_app() -> None:
 
             label = ttk.Label(row, text=hobby[1], anchor="w", style="Heading.TLabel", justify="left")
             label.grid(row=0, column=0, sticky="ew", padx=10, pady=8)
-            label.bind("<Configure>", lambda e: e.widget.config(wraplength=e.width))
+            label.bind("<Configure>", _fit_label)
 
             button_frame = ttk.Frame(row, style="Surface.TFrame")
             button_frame.grid(row=0, column=1, sticky="e", padx=10, pady=8)
@@ -188,7 +203,7 @@ def start_app() -> None:
 
                 label = ttk.Label(row, text=item[2], anchor="w", justify="left")
                 label.pack(side="left", fill="x", expand=True)
-                label.bind("<Configure>", lambda e: e.widget.config(wraplength=e.width))
+                label.bind("<Configure>", _fit_label)
 
                 def edit_subitem(subitem_id=item[0], current_name=item[2]):
                     

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -12,7 +12,10 @@ def start_app() -> None:
     """Launch the main HobbyPicker window."""
     root = tk.Tk()
     root.title("HobbyPicker")
-    root.state("zoomed")  # maximized but keeps window controls
+    # Ajustar tamaño a la resolución actual de la pantalla
+    screen_width = root.winfo_screenwidth()
+    screen_height = root.winfo_screenheight()
+    root.geometry(f"{screen_width}x{screen_height}")
     root.resizable(False, False)
 
     current_theme = tk.StringVar(value=load_theme())
@@ -40,9 +43,6 @@ def start_app() -> None:
     )
     menubar.add_cascade(label="Tema", menu=theme_menu)
     root.config(menu=menubar)
-
-    screen_width = root.winfo_screenwidth()
-    screen_height = root.winfo_screenheight()
 
     notebook = ttk.Notebook(root)
     notebook.pack(fill="both", expand=True)
@@ -150,8 +150,9 @@ def start_app() -> None:
             row.columnconfigure(0, weight=1)
             row.columnconfigure(1, weight=0)
 
-            label = ttk.Label(row, text=hobby[1], anchor="w", style="Heading.TLabel")
-            label.grid(row=0, column=0, sticky="w", padx=10, pady=8)
+            label = ttk.Label(row, text=hobby[1], anchor="w", style="Heading.TLabel", justify="left")
+            label.grid(row=0, column=0, sticky="ew", padx=10, pady=8)
+            label.bind("<Configure>", lambda e: e.widget.config(wraplength=e.width))
 
             button_frame = ttk.Frame(row, style="Surface.TFrame")
             button_frame.grid(row=0, column=1, sticky="e", padx=10, pady=8)
@@ -185,8 +186,9 @@ def start_app() -> None:
                 row = ttk.Frame(items_frame, style="Surface.TFrame")
                 row.pack(fill="x", pady=2, padx=10)
 
-                label = ttk.Label(row, text=item[2], anchor="w")
-                label.pack(side="left", expand=True)
+                label = ttk.Label(row, text=item[2], anchor="w", justify="left")
+                label.pack(side="left", fill="x", expand=True)
+                label.bind("<Configure>", lambda e: e.widget.config(wraplength=e.width))
 
                 def edit_subitem(subitem_id=item[0], current_name=item[2]):
                     

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -74,9 +74,9 @@ def start_app() -> None:
 
     root.after(100, refresh_wheel)
 
-    def _fit_label(event):
+    def _fit_label(widget):
         """Shrink label font so text fits within its width."""
-        widget = event.widget
+        widget.update_idletasks()
         widget.config(wraplength=widget.winfo_width())
         if not hasattr(widget, "_dyn_font"):
             widget._dyn_font = font.Font(font=widget.cget("font"))
@@ -89,12 +89,18 @@ def start_app() -> None:
             size -= 1
             fnt.configure(size=size)
 
+    suggestion_label.bind("<Configure>", lambda e: _fit_label(e.widget))
+
     current_item = {"id": None, "name": None}
+
+    def set_suggestion(text: str) -> None:
+        suggestion_label.config(text=text)
+        _fit_label(suggestion_label)
 
     def suggest():
         result = use_cases.get_weighted_random_valid_activity()
         if not result:
-            suggestion_label.config(text="No hay hobbies configurados. Ve a la pestaña de configuración.")
+            set_suggestion("No hay hobbies configurados. Ve a la pestaña de configuración.")
             return
 
         final_id, final_text = result
@@ -103,9 +109,7 @@ def start_app() -> None:
 
         wheel.spin_to(
             final_id,
-            on_step=lambda _id, name: suggestion_label.config(
-                text=f"¿Qué tal hacer: {name}?"
-            ),
+            on_step=lambda _id, name: set_suggestion(f"¿Qué tal hacer: {name}?"),
         )
 
     def accept():
@@ -113,7 +117,7 @@ def start_app() -> None:
             use_cases.mark_item_as_done(current_item["id"])
             current_item["id"] = None
             current_item["name"] = None
-            suggestion_label.config(text="Pulsa el botón para sugerencia")
+            set_suggestion("Pulsa el botón para sugerencia")
             refresh_wheel()
             wheel.highlight(None)
 
@@ -167,7 +171,7 @@ def start_app() -> None:
 
             label = ttk.Label(row, text=hobby[1], anchor="w", style="Heading.TLabel", justify="left")
             label.grid(row=0, column=0, sticky="ew", padx=10, pady=8)
-            label.bind("<Configure>", _fit_label)
+            label.bind("<Configure>", lambda e: _fit_label(e.widget))
 
             button_frame = ttk.Frame(row, style="Surface.TFrame")
             button_frame.grid(row=0, column=1, sticky="e", padx=10, pady=8)
@@ -203,7 +207,7 @@ def start_app() -> None:
 
                 label = ttk.Label(row, text=item[2], anchor="w", justify="left")
                 label.pack(side="left", fill="x", expand=True)
-                label.bind("<Configure>", _fit_label)
+                label.bind("<Configure>", lambda e: _fit_label(e.widget))
 
                 def edit_subitem(subitem_id=item[0], current_name=item[2]):
                     

--- a/presentation/widgets/roulette_canvas.py
+++ b/presentation/widgets/roulette_canvas.py
@@ -48,7 +48,7 @@ class RouletteCanvas(tk.Canvas):
             "#264653", "#2a9d8f", "#e9c46a", "#f4a261",
             "#e76f51", "#6a4c93", "#8ac926", "#1982c4",
         ]
-        text_font = font.Font(family="Helvetica", size=14, weight="bold")
+        base_font = font.Font(family="Helvetica", size=14, weight="bold")
         max_text_width = self.radius * 1.2
         for idx, item in enumerate(items):
             extent = item['weight'] / total * 360
@@ -66,11 +66,9 @@ class RouletteCanvas(tk.Canvas):
             self._arcs[item['id']] = arc
             self._order.append(item['id'])
             name = item['name']
-            draw_name = name
-            if text_font.measure(draw_name) > max_text_width:
-                while text_font.measure(draw_name + "…") > max_text_width and draw_name:
-                    draw_name = draw_name[:-1]
-                draw_name = draw_name + "…"
+            text_font = font.Font(font=base_font)
+            while text_font.cget("size") > 8 and text_font.measure(name) > max_text_width:
+                text_font.configure(size=text_font.cget("size") - 1)
             self._names[item['id']] = name
             mid = start + extent / 2
             x = self.center[0] + self.radius * 0.7 * math.cos(math.radians(mid))
@@ -78,7 +76,7 @@ class RouletteCanvas(tk.Canvas):
             self.create_text(
                 x,
                 y,
-                text=f"{draw_name}\n{item['percentage']:.1f}%",
+                text=f"{name}\n{item['percentage']:.1f}%",
                 fill="white",
                 font=text_font,
                 justify="center",
@@ -121,6 +119,13 @@ class RouletteCanvas(tk.Canvas):
         target_index = rev_order.index(activity_id)
         path += rev_order[: target_index + 1]
         total_steps = len(path)
+        max_duration = 5000  # ms
+        avg_delay = base_delay + extra_delay / 3
+        expected = total_steps * avg_delay
+        if expected > max_duration:
+            scale = max_duration / expected
+            base_delay *= scale
+            extra_delay *= scale
 
         def step(i=0):
             current_id = path[i]


### PR DESCRIPTION
## Summary
- auto-size window to screen resolution
- wrap long hobby names in configuration list
- wrap long subitem names in edit dialogs

## Testing
- `python -m py_compile presentation/app.py`
