### PR TITLE
feat: show probability table

### DIFF
--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -52,19 +52,17 @@ def get_activity_probabilities():
     activities = dao.get_all_with_counts()
     if not activities:
         return []
-
     max_count = max(a[2] for a in activities) + 1
-    total_weight = sum(max_count - a[2] for a in activities)
-
-    result = []
+    weighted = []
     for hobby_id, name, count in activities:
         weight = max_count - count
         subitems = dao.get_subitems_by_activity(hobby_id)
         if subitems:
-            sub_prob = weight / total_weight / len(subitems)
             for sub in subitems:
-                result.append((f"{name} + {sub[2]}", sub_prob))
+                weighted.append((f"{name} + {sub[2]}", weight))
         else:
-            result.append((name, weight / total_weight))
-    return result
+            weighted.append((name, weight))
+
+    total_weight = sum(w for _, w in weighted)
+    return [(name, w / total_weight) for name, w in weighted]
 

--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -46,3 +46,25 @@ def delete_hobby(hobby_id):
 
 def update_subitem(subitem_id, new_name):
     dao.update_subitem(subitem_id, new_name)
+
+
+def get_activity_probabilities():
+    activities = dao.get_all_with_counts()
+    if not activities:
+        return []
+
+    max_count = max(a[2] for a in activities) + 1
+    total_weight = sum(max_count - a[2] for a in activities)
+
+    result = []
+    for hobby_id, name, count in activities:
+        weight = max_count - count
+        subitems = dao.get_subitems_by_activity(hobby_id)
+        if subitems:
+            sub_prob = weight / total_weight / len(subitems)
+            for sub in subitems:
+                result.append((f"{name} + {sub[2]}", sub_prob))
+        else:
+            result.append((name, weight / total_weight))
+    return result
+

--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -58,8 +58,9 @@ def get_activity_probabilities():
         weight = max_count - count
         subitems = dao.get_subitems_by_activity(hobby_id)
         if subitems:
+            portion = weight / len(subitems)
             for sub in subitems:
-                weighted.append((f"{name} + {sub[2]}", weight))
+                weighted.append((f"{name} + {sub[2]}", portion))
         else:
             weighted.append((name, weight))
 

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -54,21 +54,29 @@ def start_app() -> None:
     content_frame.grid(row=0, column=0, sticky="nsew")
 
     table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=220)
-    table_frame.grid(row=0, column=1, sticky="ns", padx=10, pady=10)
+    table_frame.grid(row=0, column=1, sticky="nsew", padx=10)
     table_frame.grid_propagate(False)
+    table_frame.rowconfigure(0, weight=1)
+    table_frame.columnconfigure(0, weight=1)
 
     prob_table = ttk.Treeview(
         table_frame,
         columns=("activity", "percent"),
         show="headings",
-        height=15,
         style="Probability.Treeview",
     )
     prob_table.heading("activity", text="Actividad")
     prob_table.heading("percent", text="%")
     prob_table.column("activity", width=160, anchor="w")
     prob_table.column("percent", width=60, anchor="center")
-    prob_table.pack(fill="y", expand=False)
+
+    v_scroll = ttk.Scrollbar(table_frame, orient="vertical", command=prob_table.yview)
+    h_scroll = ttk.Scrollbar(table_frame, orient="horizontal", command=prob_table.xview)
+    prob_table.configure(yscrollcommand=v_scroll.set, xscrollcommand=h_scroll.set)
+
+    prob_table.grid(row=0, column=0, sticky="nsew")
+    v_scroll.grid(row=0, column=1, sticky="ns")
+    h_scroll.grid(row=1, column=0, sticky="ew")
 
     def refresh_probabilities():
         for row in prob_table.get_children():
@@ -84,6 +92,7 @@ def start_app() -> None:
         font=("Segoe UI", 28, "bold"),
         wraplength=500,
         justify="center",
+        style="Surface.TLabel",
     )
     suggestion_label.pack(pady=(60, 40), expand=True)
 
@@ -125,7 +134,7 @@ def start_app() -> None:
             suggestion_label.config(text="Pulsa el botón para sugerencia")
             refresh_probabilities()
 
-    button_container = ttk.Frame(content_frame)
+    button_container = ttk.Frame(content_frame, style="Surface.TFrame")
     button_container.pack(pady=(20, 40))
 
     ttk.Button(
@@ -150,22 +159,22 @@ def start_app() -> None:
 
     notebook.bind("<<NotebookTabChanged>>", on_tab_change)
 
-    # --- Pestaña: Configurar gustos ---
-    frame_config = ttk.Frame(notebook)
-    notebook.add(frame_config, text="⚙️ Configurar gustos")
+    # --- Pestaña: Configurar hobbies ---
+    frame_config = ttk.Frame(notebook, style="Surface.TFrame")
+    notebook.add(frame_config, text="⚙️ Configurar hobbies")
 
-    main_config_layout = ttk.Frame(frame_config)
+    main_config_layout = ttk.Frame(frame_config, style="Surface.TFrame")
     main_config_layout.pack(fill="both", expand=True)
 
     canvas = tk.Canvas(
-        main_config_layout, bg=get_color("background"), highlightthickness=0
+        main_config_layout, bg=get_color("surface"), highlightthickness=0
     )
     scrollbar = ttk.Scrollbar(
         main_config_layout, orient="vertical", command=canvas.yview
     )
     canvas.configure(yscrollcommand=scrollbar.set)
 
-    scrollable_frame = ttk.Frame(canvas)
+    scrollable_frame = ttk.Frame(canvas, style="Surface.TFrame")
 
     def update_scrollregion(e=None):
         canvas.configure(scrollregion=canvas.bbox("all"))
@@ -181,7 +190,7 @@ def start_app() -> None:
     canvas.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
 
-    sticky_bottom = ttk.Frame(main_config_layout)
+    sticky_bottom = ttk.Frame(main_config_layout, style="Surface.TFrame")
     sticky_bottom.pack(fill="x", side="bottom", pady=5)
     ttk.Button(
         sticky_bottom, text="➕ Añadir hobby", command=lambda: open_add_hobby_window()
@@ -200,7 +209,7 @@ def start_app() -> None:
             row.columnconfigure(1, weight=0)
 
             label = ttk.Label(
-                row, text=hobby[1], anchor="w", style="Heading.TLabel"
+                row, text=hobby[1], anchor="w", style="Heading.Surface.TLabel"
             )
             label.grid(row=0, column=0, sticky="w", padx=10, pady=8)
 
@@ -235,7 +244,7 @@ def start_app() -> None:
         edit_window.minsize(400, 600)
 
         ttk.Label(edit_window, text="Subelementos:").pack(pady=5)
-        items_frame = ttk.Frame(edit_window)
+        items_frame = ttk.Frame(edit_window, style="Surface.TFrame")
         items_frame.pack(fill="both", expand=True, pady=5)
 
         def refresh_items():
@@ -245,7 +254,7 @@ def start_app() -> None:
                 row = ttk.Frame(items_frame, style="Surface.TFrame")
                 row.pack(fill="x", pady=2, padx=10)
 
-                label = ttk.Label(row, text=item[2], anchor="w")
+                label = ttk.Label(row, text=item[2], anchor="w", style="Surface.TLabel")
                 label.pack(side="left", expand=True)
 
                 def edit_subitem(subitem_id=item[0], current_name=item[2]):

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -47,8 +47,35 @@ def start_app() -> None:
     frame_suggest = ttk.Frame(notebook, style="Surface.TFrame")
     notebook.add(frame_suggest, text="¿Qué hago hoy?")
 
+    content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
+    content_frame.pack(side="left", fill="both", expand=True)
+
+    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
+    table_frame.pack(side="right", fill="y", padx=10, pady=10)
+
+    prob_table = ttk.Treeview(
+        table_frame,
+        columns=("activity", "percent"),
+        show="headings",
+        height=15,
+        style="Probability.Treeview",
+    )
+    prob_table.heading("activity", text="Actividad")
+    prob_table.heading("percent", text="%")
+    prob_table.column("activity", width=160, anchor="w")
+    prob_table.column("percent", width=60, anchor="center")
+    prob_table.pack(fill="y", expand=False)
+
+    def refresh_probabilities():
+        for row in prob_table.get_children():
+            prob_table.delete(row)
+        for name, prob in use_cases.get_activity_probabilities():
+            prob_table.insert("", "end", values=(name, f"{prob*100:.1f}%"))
+
+    refresh_probabilities()
+
     suggestion_label = ttk.Label(
-        frame_suggest,
+        content_frame,
         text="Pulsa el botón para sugerencia",
         font=("Segoe UI", 28, "bold"),
         wraplength=700,
@@ -92,8 +119,9 @@ def start_app() -> None:
             current_activity["id"] = None
             current_activity["name"] = None
             suggestion_label.config(text="Pulsa el botón para sugerencia")
+            refresh_probabilities()
 
-    button_container = ttk.Frame(frame_suggest)
+    button_container = ttk.Frame(content_frame)
     button_container.pack(pady=(20, 40))
 
     ttk.Button(
@@ -111,6 +139,12 @@ def start_app() -> None:
         style="Big.TButton",
         width=20,
     ).pack(pady=10)
+
+    def on_tab_change(event):
+        if notebook.index("current") == 0:
+            refresh_probabilities()
+
+    notebook.bind("<<NotebookTabChanged>>", on_tab_change)
 
     # --- Pestaña: Configurar gustos ---
     frame_config = ttk.Frame(notebook)

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -10,9 +10,9 @@ from presentation.widgets.simple_entry_dialog import SimpleEntryDialog
 def start_app() -> None:
     """Launch the main HobbyPicker window."""
     root = tk.Tk()
-    WindowUtils.center_window(root, 800, 600)
+    WindowUtils.center_window(root, 1020, 600)
     root.title("HobbyPicker")
-    root.minsize(800, 600)
+    root.minsize(1020, 600)
 
     apply_style(root, "system")
     canvas = None  # se asigna más tarde
@@ -53,7 +53,7 @@ def start_app() -> None:
     content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
     content_frame.grid(row=0, column=0, sticky="nsew")
 
-    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=220)
+    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=440)
     table_frame.grid(row=0, column=1, sticky="nsew", padx=10)
     table_frame.grid_propagate(False)
     table_frame.rowconfigure(0, weight=1)
@@ -67,8 +67,8 @@ def start_app() -> None:
     )
     prob_table.heading("activity", text="Actividad")
     prob_table.heading("percent", text="%")
-    prob_table.column("activity", width=160, anchor="w")
-    prob_table.column("percent", width=60, anchor="center")
+    prob_table.column("activity", width=320, anchor="w")
+    prob_table.column("percent", width=120, anchor="center")
 
     v_scroll = ttk.Scrollbar(table_frame, orient="vertical", command=prob_table.yview)
     h_scroll = ttk.Scrollbar(table_frame, orient="horizontal", command=prob_table.xview)
@@ -202,7 +202,9 @@ def start_app() -> None:
         for widget in hobbies_container.winfo_children():
             widget.destroy()
         for hobby in use_cases.get_all_hobbies():
-            row = ttk.Frame(hobbies_container, style="Surface.TFrame")
+            row = ttk.Frame(
+                hobbies_container, style="Outlined.Surface.TFrame", padding=5
+            )
             row.pack(fill="x", pady=4, padx=10)
 
             row.columnconfigure(0, weight=1)
@@ -251,7 +253,9 @@ def start_app() -> None:
             for w in items_frame.winfo_children():
                 w.destroy()
             for item in use_cases.get_subitems_for_hobby(hobby_id):
-                row = ttk.Frame(items_frame, style="Surface.TFrame")
+                row = ttk.Frame(
+                    items_frame, style="Outlined.Surface.TFrame", padding=5
+                )
                 row.pack(fill="x", pady=2, padx=10)
 
                 label = ttk.Label(row, text=item[2], anchor="w", style="Surface.TLabel")

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -47,11 +47,15 @@ def start_app() -> None:
     frame_suggest = ttk.Frame(notebook, style="Surface.TFrame")
     notebook.add(frame_suggest, text="¿Qué hago hoy?")
 
-    content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
-    content_frame.pack(side="left", fill="both", expand=True)
+    frame_suggest.columnconfigure(0, weight=1)
+    frame_suggest.rowconfigure(0, weight=1)
 
-    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
-    table_frame.pack(side="right", fill="y", padx=10, pady=10)
+    content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
+    content_frame.grid(row=0, column=0, sticky="nsew")
+
+    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=220)
+    table_frame.grid(row=0, column=1, sticky="ns", padx=10, pady=10)
+    table_frame.grid_propagate(False)
 
     prob_table = ttk.Treeview(
         table_frame,
@@ -78,7 +82,7 @@ def start_app() -> None:
         content_frame,
         text="Pulsa el botón para sugerencia",
         font=("Segoe UI", 28, "bold"),
-        wraplength=700,
+        wraplength=500,
         justify="center",
     )
     suggestion_label.pack(pady=(60, 40), expand=True)

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -10,9 +10,9 @@ from presentation.widgets.simple_entry_dialog import SimpleEntryDialog
 def start_app() -> None:
     """Launch the main HobbyPicker window."""
     root = tk.Tk()
-    WindowUtils.center_window(root, 1020, 600)
+    WindowUtils.center_window(root, 1240, 600)
     root.title("HobbyPicker")
-    root.minsize(1020, 600)
+    root.minsize(1240, 600)
 
     apply_style(root, "system")
     canvas = None  # se asigna más tarde
@@ -53,7 +53,7 @@ def start_app() -> None:
     content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
     content_frame.grid(row=0, column=0, sticky="nsew")
 
-    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=440)
+    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=660)
     table_frame.grid(row=0, column=1, sticky="nsew", padx=10)
     table_frame.grid_propagate(False)
     table_frame.rowconfigure(0, weight=1)
@@ -67,16 +67,14 @@ def start_app() -> None:
     )
     prob_table.heading("activity", text="Actividad")
     prob_table.heading("percent", text="%")
-    prob_table.column("activity", width=320, anchor="w")
-    prob_table.column("percent", width=120, anchor="center")
+    prob_table.column("activity", width=480, anchor="w")
+    prob_table.column("percent", width=180, anchor="center")
 
     v_scroll = ttk.Scrollbar(table_frame, orient="vertical", command=prob_table.yview)
-    h_scroll = ttk.Scrollbar(table_frame, orient="horizontal", command=prob_table.xview)
-    prob_table.configure(yscrollcommand=v_scroll.set, xscrollcommand=h_scroll.set)
+    prob_table.configure(yscrollcommand=v_scroll.set)
 
     prob_table.grid(row=0, column=0, sticky="nsew")
     v_scroll.grid(row=0, column=1, sticky="ns")
-    h_scroll.grid(row=1, column=0, sticky="ew")
 
     def refresh_probabilities():
         for row in prob_table.get_children():

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -145,3 +145,23 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     if master is not None:
         master.configure(bg=background)
 
+    style.configure(
+        "Probability.Treeview",
+        background=surface,
+        fieldbackground=surface,
+        foreground=text,
+        bordercolor=light,
+        borderwidth=1,
+        rowheight=24,
+    )
+    style.map(
+        "Probability.Treeview",
+        background=[("selected", primary)],
+    )
+    style.configure(
+        "Probability.Treeview.Heading",
+        background=light,
+        foreground=text,
+        font=bold_font,
+    )
+

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -97,7 +97,16 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         borderwidth=surface_border,
     )
     style.configure("TLabel", background=background, font=base_font, foreground=text)
+    style.configure(
+        "Surface.TLabel", background=surface, font=base_font, foreground=text
+    )
     style.configure("Heading.TLabel", font=large_font)
+    style.configure(
+        "Heading.Surface.TLabel",
+        background=surface,
+        font=large_font,
+        foreground=text,
+    )
     style.configure("TEntry", relief="flat", padding=6, foreground="black")
     style.map("TEntry", foreground=[("focus", "black")])
 
@@ -136,8 +145,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     style.configure("TRadiobutton", background=background, padding=5)
     style.configure("TCheckbutton", background=background, padding=5)
 
-    style.configure(
-        "Vertical.TScrollbar",
+    scroll_conf = dict(
         gripcount=0,
         background=light,
         darkcolor=light,
@@ -146,6 +154,8 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         bordercolor=light,
         arrowcolor=primary,
     )
+    style.configure("Vertical.TScrollbar", **scroll_conf)
+    style.configure("Horizontal.TScrollbar", **scroll_conf)
 
     style.configure("Toplevel", background=background)
 

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -88,11 +88,18 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
 
     style.configure(".", background=background, foreground=text, font=base_font)
     style.configure("TFrame", background=background)
-    style.configure("Surface.TFrame", background=surface, relief="ridge", borderwidth=1)
+    surface_border = 0 if theme == "dark" else 1
+    surface_relief = "flat" if theme == "dark" else "ridge"
+    style.configure(
+        "Surface.TFrame",
+        background=surface,
+        relief=surface_relief,
+        borderwidth=surface_border,
+    )
     style.configure("TLabel", background=background, font=base_font, foreground=text)
     style.configure("Heading.TLabel", font=large_font)
-    style.configure("TEntry", relief="flat", padding=6)
-    style.map("TEntry", foreground=[("focus", text)])
+    style.configure("TEntry", relief="flat", padding=6, foreground="black")
+    style.map("TEntry", foreground=[("focus", "black")])
 
     style.configure("TNotebook", background=background, padding=10)
     style.configure(
@@ -145,13 +152,14 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     if master is not None:
         master.configure(bg=background)
 
+    tree_border = 0 if theme == "dark" else 1
     style.configure(
         "Probability.Treeview",
         background=surface,
         fieldbackground=surface,
         foreground=text,
         bordercolor=light,
-        borderwidth=1,
+        borderwidth=tree_border,
         rowheight=24,
     )
     style.map(
@@ -163,5 +171,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         background=light,
         foreground=text,
         font=bold_font,
+        relief="flat",
+        borderwidth=0,
     )
 

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -81,6 +81,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     light = palette["light"]
     text = palette["text"]
     subtle = palette["subtle"]
+    contrast = "#FFFFFF" if theme == "dark" else "#000000"
 
     base_font = ("Helvetica", 11)
     bold_font = ("Helvetica", 11, "bold")
@@ -95,6 +96,13 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         background=surface,
         relief=surface_relief,
         borderwidth=surface_border,
+    )
+    style.configure(
+        "Outlined.Surface.TFrame",
+        background=surface,
+        bordercolor=contrast,
+        borderwidth=1,
+        relief="solid",
     )
     style.configure("TLabel", background=background, font=base_font, foreground=text)
     style.configure(


### PR DESCRIPTION
## Summary
- display activity probabilities in a right-side table
- compute fair percentages including subitems
- style table to match application theme

## Testing
- `python -m py_compile domain/use_cases.py presentation/app.py presentation/widgets/styles.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f92358bc83338842656cd9677f42