### PR TITLE
Añade separador y centra encabezado de actividad

### DIFF
--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -46,3 +46,24 @@ def delete_hobby(hobby_id):
 
 def update_subitem(subitem_id, new_name):
     dao.update_subitem(subitem_id, new_name)
+
+
+def get_activity_probabilities():
+    activities = dao.get_all_with_counts()
+    if not activities:
+        return []
+    max_count = max(a[2] for a in activities) + 1
+    weighted = []
+    for hobby_id, name, count in activities:
+        weight = max_count - count
+        subitems = dao.get_subitems_by_activity(hobby_id)
+        if subitems:
+            portion = weight / len(subitems)
+            for sub in subitems:
+                weighted.append((f"{name} + {sub[2]}", portion))
+        else:
+            weighted.append((name, weight))
+
+    total_weight = sum(w for _, w in weighted)
+    return [(name, w / total_weight) for name, w in weighted]
+

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -10,12 +10,13 @@ from presentation.widgets.simple_entry_dialog import SimpleEntryDialog
 def start_app() -> None:
     """Launch the main HobbyPicker window."""
     root = tk.Tk()
-    WindowUtils.center_window(root, 800, 600)
+    WindowUtils.center_window(root, 1240, 600)
     root.title("HobbyPicker")
-    root.minsize(800, 600)
+    root.minsize(1240, 600)
 
     apply_style(root, "system")
     canvas = None  # se asigna más tarde
+    separator = None  # línea divisoria asignada después
 
     # --- Notebook principal ---
     notebook = ttk.Notebook(root)
@@ -29,6 +30,8 @@ def start_app() -> None:
         apply_style(root, theme_options[value])
         if canvas is not None:
             canvas.configure(bg=get_color("background"))
+        if separator is not None:
+            separator.configure(bg=get_color("contrast"))
 
     menubar = tk.Menu(root)
     theme_menu = tk.Menu(menubar, tearoff=0)
@@ -47,12 +50,55 @@ def start_app() -> None:
     frame_suggest = ttk.Frame(notebook, style="Surface.TFrame")
     notebook.add(frame_suggest, text="¿Qué hago hoy?")
 
+    frame_suggest.columnconfigure(0, weight=1)
+    frame_suggest.columnconfigure(1, weight=0)
+    frame_suggest.columnconfigure(2, weight=0)
+    frame_suggest.rowconfigure(0, weight=1)
+
+    content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
+    content_frame.grid(row=0, column=0, sticky="nsew")
+
+    separator = tk.Frame(frame_suggest, width=2, bg=get_color("contrast"))
+    separator.grid(row=0, column=1, sticky="ns")
+
+    table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=660)
+    table_frame.grid(row=0, column=2, sticky="nsew", padx=10)
+    table_frame.grid_propagate(False)
+    table_frame.rowconfigure(0, weight=1)
+    table_frame.columnconfigure(0, weight=1)
+
+    prob_table = ttk.Treeview(
+        table_frame,
+        columns=("activity", "percent"),
+        show="headings",
+        style="Probability.Treeview",
+    )
+    prob_table.heading("activity", text="Actividad", anchor="center")
+    prob_table.heading("percent", text="%", anchor="center")
+    prob_table.column("activity", width=480, anchor="center")
+    prob_table.column("percent", width=180, anchor="center")
+
+    v_scroll = ttk.Scrollbar(table_frame, orient="vertical", command=prob_table.yview)
+    prob_table.configure(yscrollcommand=v_scroll.set)
+
+    prob_table.grid(row=0, column=0, sticky="nsew")
+    v_scroll.grid(row=0, column=1, sticky="ns")
+
+    def refresh_probabilities():
+        for row in prob_table.get_children():
+            prob_table.delete(row)
+        for name, prob in use_cases.get_activity_probabilities():
+            prob_table.insert("", "end", values=(name, f"{prob*100:.1f}%"))
+
+    refresh_probabilities()
+
     suggestion_label = ttk.Label(
-        frame_suggest,
+        content_frame,
         text="Pulsa el botón para sugerencia",
         font=("Segoe UI", 28, "bold"),
-        wraplength=700,
+        wraplength=500,
         justify="center",
+        style="Surface.TLabel",
     )
     suggestion_label.pack(pady=(60, 40), expand=True)
 
@@ -92,8 +138,9 @@ def start_app() -> None:
             current_activity["id"] = None
             current_activity["name"] = None
             suggestion_label.config(text="Pulsa el botón para sugerencia")
+            refresh_probabilities()
 
-    button_container = ttk.Frame(frame_suggest)
+    button_container = ttk.Frame(content_frame, style="Surface.TFrame")
     button_container.pack(pady=(20, 40))
 
     ttk.Button(
@@ -112,22 +159,28 @@ def start_app() -> None:
         width=20,
     ).pack(pady=10)
 
-    # --- Pestaña: Configurar gustos ---
-    frame_config = ttk.Frame(notebook)
-    notebook.add(frame_config, text="⚙️ Configurar gustos")
+    def on_tab_change(event):
+        if notebook.index("current") == 0:
+            refresh_probabilities()
 
-    main_config_layout = ttk.Frame(frame_config)
+    notebook.bind("<<NotebookTabChanged>>", on_tab_change)
+
+    # --- Pestaña: Configurar hobbies ---
+    frame_config = ttk.Frame(notebook, style="Surface.TFrame")
+    notebook.add(frame_config, text="⚙️ Configurar hobbies")
+
+    main_config_layout = ttk.Frame(frame_config, style="Surface.TFrame")
     main_config_layout.pack(fill="both", expand=True)
 
     canvas = tk.Canvas(
-        main_config_layout, bg=get_color("background"), highlightthickness=0
+        main_config_layout, bg=get_color("surface"), highlightthickness=0
     )
     scrollbar = ttk.Scrollbar(
         main_config_layout, orient="vertical", command=canvas.yview
     )
     canvas.configure(yscrollcommand=scrollbar.set)
 
-    scrollable_frame = ttk.Frame(canvas)
+    scrollable_frame = ttk.Frame(canvas, style="Surface.TFrame")
 
     def update_scrollregion(e=None):
         canvas.configure(scrollregion=canvas.bbox("all"))
@@ -143,7 +196,7 @@ def start_app() -> None:
     canvas.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
 
-    sticky_bottom = ttk.Frame(main_config_layout)
+    sticky_bottom = ttk.Frame(main_config_layout, style="Surface.TFrame")
     sticky_bottom.pack(fill="x", side="bottom", pady=5)
     ttk.Button(
         sticky_bottom, text="➕ Añadir hobby", command=lambda: open_add_hobby_window()
@@ -155,14 +208,16 @@ def start_app() -> None:
         for widget in hobbies_container.winfo_children():
             widget.destroy()
         for hobby in use_cases.get_all_hobbies():
-            row = ttk.Frame(hobbies_container, style="Surface.TFrame")
+            row = ttk.Frame(
+                hobbies_container, style="Outlined.Surface.TFrame", padding=5
+            )
             row.pack(fill="x", pady=4, padx=10)
 
             row.columnconfigure(0, weight=1)
             row.columnconfigure(1, weight=0)
 
             label = ttk.Label(
-                row, text=hobby[1], anchor="w", style="Heading.TLabel"
+                row, text=hobby[1], anchor="w", style="Heading.Surface.TLabel"
             )
             label.grid(row=0, column=0, sticky="w", padx=10, pady=8)
 
@@ -197,17 +252,19 @@ def start_app() -> None:
         edit_window.minsize(400, 600)
 
         ttk.Label(edit_window, text="Subelementos:").pack(pady=5)
-        items_frame = ttk.Frame(edit_window)
+        items_frame = ttk.Frame(edit_window, style="Surface.TFrame")
         items_frame.pack(fill="both", expand=True, pady=5)
 
         def refresh_items():
             for w in items_frame.winfo_children():
                 w.destroy()
             for item in use_cases.get_subitems_for_hobby(hobby_id):
-                row = ttk.Frame(items_frame, style="Surface.TFrame")
+                row = ttk.Frame(
+                    items_frame, style="Outlined.Surface.TFrame", padding=5
+                )
                 row.pack(fill="x", pady=2, padx=10)
 
-                label = ttk.Label(row, text=item[2], anchor="w")
+                label = ttk.Label(row, text=item[2], anchor="w", style="Surface.TLabel")
                 label.pack(side="left", expand=True)
 
                 def edit_subitem(subitem_id=item[0], current_name=item[2]):

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -57,6 +57,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
             "light": "#3A3A3A",
             "text": "#FFFFFF",
             "subtle": "#CCCCCC",
+            "contrast": "#FFFFFF",
         }
     else:  # light theme
         palette = {
@@ -67,6 +68,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
             "light": "#D1D9E0",
             "text": "#1F2A36",
             "subtle": "#6B7785",
+            "contrast": "#000000",
         }
 
     _CURRENT_PALETTE = palette
@@ -81,6 +83,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     light = palette["light"]
     text = palette["text"]
     subtle = palette["subtle"]
+    contrast = palette["contrast"]
 
     base_font = ("Helvetica", 11)
     bold_font = ("Helvetica", 11, "bold")
@@ -88,11 +91,34 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
 
     style.configure(".", background=background, foreground=text, font=base_font)
     style.configure("TFrame", background=background)
-    style.configure("Surface.TFrame", background=surface, relief="ridge", borderwidth=1)
+    surface_border = 0 if theme == "dark" else 1
+    surface_relief = "flat" if theme == "dark" else "ridge"
+    style.configure(
+        "Surface.TFrame",
+        background=surface,
+        relief=surface_relief,
+        borderwidth=surface_border,
+    )
+    style.configure(
+        "Outlined.Surface.TFrame",
+        background=surface,
+        bordercolor=contrast,
+        borderwidth=1,
+        relief="solid",
+    )
     style.configure("TLabel", background=background, font=base_font, foreground=text)
+    style.configure(
+        "Surface.TLabel", background=surface, font=base_font, foreground=text
+    )
     style.configure("Heading.TLabel", font=large_font)
-    style.configure("TEntry", relief="flat", padding=6)
-    style.map("TEntry", foreground=[("focus", text)])
+    style.configure(
+        "Heading.Surface.TLabel",
+        background=surface,
+        font=large_font,
+        foreground=text,
+    )
+    style.configure("TEntry", relief="flat", padding=6, foreground="black")
+    style.map("TEntry", foreground=[("focus", "black")])
 
     style.configure("TNotebook", background=background, padding=10)
     style.configure(
@@ -129,8 +155,7 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
     style.configure("TRadiobutton", background=background, padding=5)
     style.configure("TCheckbutton", background=background, padding=5)
 
-    style.configure(
-        "Vertical.TScrollbar",
+    scroll_conf = dict(
         gripcount=0,
         background=light,
         darkcolor=light,
@@ -139,9 +164,34 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         bordercolor=light,
         arrowcolor=primary,
     )
+    style.configure("Vertical.TScrollbar", **scroll_conf)
+    style.configure("Horizontal.TScrollbar", **scroll_conf)
 
     style.configure("Toplevel", background=background)
 
     if master is not None:
         master.configure(bg=background)
+
+    tree_border = 0 if theme == "dark" else 1
+    style.configure(
+        "Probability.Treeview",
+        background=surface,
+        fieldbackground=surface,
+        foreground=text,
+        bordercolor=light,
+        borderwidth=tree_border,
+        rowheight=24,
+    )
+    style.map(
+        "Probability.Treeview",
+        background=[("selected", primary)],
+    )
+    style.configure(
+        "Probability.Treeview.Heading",
+        background=light,
+        foreground=text,
+        font=bold_font,
+        relief="flat",
+        borderwidth=0,
+    )
 


### PR DESCRIPTION
## Summary
- Se añade un separador vertical con color de contraste entre el área principal y la tabla de porcentajes
- Se centra el texto de la columna "Actividad" en la tabla de probabilidades
- Se expone un color de contraste en el sistema de estilos para adaptarlo al tema claro/oscuro

## Testing
- `python -m py_compile domain/use_cases.py presentation/app.py presentation/widgets/styles.py`