### PR TITLE
Handle subitems individually and improve dark theme UI

### DIFF
--- a/data/activity_dao.py
+++ b/data/activity_dao.py
@@ -28,8 +28,15 @@ class ActivityDAO:
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         activity_id INTEGER,
                         name TEXT,
+                        accepted_count INTEGER DEFAULT 0,
                         FOREIGN KEY (activity_id) REFERENCES activities(id)
                     )""")
+        try:
+            c.execute(
+                "ALTER TABLE subitems ADD COLUMN accepted_count INTEGER DEFAULT 0"
+            )
+        except sqlite3.OperationalError:
+            pass
         self.conn.commit()
 
     def get_all_activities(self):
@@ -37,7 +44,8 @@ class ActivityDAO:
 
     def get_subitems_by_activity(self, activity_id):
         return self.conn.execute(
-            "SELECT id, activity_id, name FROM subitems WHERE activity_id = ?", (activity_id,)
+            "SELECT id, activity_id, name, accepted_count FROM subitems WHERE activity_id = ?",
+            (activity_id,),
         ).fetchall()
 
     def get_random_with_subitems(self):
@@ -63,6 +71,13 @@ class ActivityDAO:
 
     def increment_accepted_count(self, activity_id):
         self.conn.execute("UPDATE activities SET accepted_count = accepted_count + 1 WHERE id = ?", (activity_id,))
+        self.conn.commit()
+
+    def increment_subitem_accepted_count(self, subitem_id):
+        self.conn.execute(
+            "UPDATE subitems SET accepted_count = accepted_count + 1 WHERE id = ?",
+            (subitem_id,),
+        )
         self.conn.commit()
 
     def accept_activity(self, activity_id):

--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -14,12 +14,12 @@ def get_weighted_random_valid_activity():
     for act in activities:
         hobby_id, name, count = act
         subitems = dao.get_subitems_by_activity(hobby_id)
-        display_name = name
-        if subitems:
-            sub = random.choice(subitems)[2]
-            display_name += f" + {sub}"
         weight = max_count - count
-        weighted.extend([(hobby_id, display_name)] * weight)
+        if subitems:
+            for sub in subitems:
+                weighted.extend([(hobby_id, f"{name} + {sub[2]}")] * weight)
+        else:
+            weighted.extend([(hobby_id, name)] * weight)
 
     return random.choice(weighted) if weighted else None
 
@@ -58,9 +58,8 @@ def get_activity_probabilities():
         weight = max_count - count
         subitems = dao.get_subitems_by_activity(hobby_id)
         if subitems:
-            portion = weight / len(subitems)
             for sub in subitems:
-                weighted.append((f"{name} + {sub[2]}", portion))
+                weighted.append((f"{name} + {sub[2]}", weight))
         else:
             weighted.append((name, weight))
 

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -101,7 +101,7 @@ def start_app() -> None:
     )
     suggestion_label.pack(pady=(60, 40), expand=True)
 
-    current_activity = {"id": None, "name": None}
+    current_activity = {"id": None, "name": None, "is_subitem": False}
 
     def suggest():
         result = use_cases.get_weighted_random_valid_activity()
@@ -111,9 +111,10 @@ def start_app() -> None:
             )
             return
 
-        final_id, final_text = result
+        final_id, final_text, is_sub = result
         current_activity["id"] = final_id
         current_activity["name"] = final_text
+        current_activity["is_subitem"] = is_sub
 
         options = []
         for _ in range(30):
@@ -133,9 +134,12 @@ def start_app() -> None:
 
     def accept():
         if current_activity["id"]:
-            use_cases.mark_activity_as_done(current_activity["id"])
+            use_cases.mark_activity_as_done(
+                current_activity["id"], current_activity["is_subitem"]
+            )
             current_activity["id"] = None
             current_activity["name"] = None
+            current_activity["is_subitem"] = False
             suggestion_label.config(text="Pulsa el botón para sugerencia")
             refresh_probabilities()
 

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -30,9 +30,7 @@ def start_app() -> None:
     def change_theme_to(value: str) -> None:
         apply_style(root, theme_options[value])
         if canvas is not None:
-            canvas.configure(bg=get_color("background"))
-        if separator is not None:
-            separator.configure(bg=get_color("contrast"))
+            canvas.configure(bg=get_color("surface"))
 
     menubar = tk.Menu(root)
     theme_menu = tk.Menu(menubar, tearoff=0)
@@ -59,8 +57,8 @@ def start_app() -> None:
     content_frame = ttk.Frame(frame_suggest, style="Surface.TFrame")
     content_frame.grid(row=0, column=0, sticky="nsew")
 
-    separator = tk.Frame(frame_suggest, width=2, bg=get_color("contrast"))
-    separator.grid(row=0, column=1, sticky="ns")
+    separator = ttk.Separator(frame_suggest, orient="vertical")
+    separator.grid(row=0, column=1, sticky="ns", padx=5)
 
     table_frame = ttk.Frame(frame_suggest, style="Surface.TFrame", width=660)
     table_frame.grid(row=0, column=2, sticky="nsew", padx=10)

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -181,6 +181,10 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
         bordercolor=light,
         borderwidth=tree_border,
         rowheight=24,
+        columnseparatorcolor=light,
+        rowseparatorcolor=light,
+        columnseparatorwidth=1,
+        rowseparatorwidth=1,
     )
     style.map(
         "Probability.Treeview",


### PR DESCRIPTION
## Summary
- Treat each subitem as an independent entry when calculating weights and probabilities
- Add a visual separator beside the probability table and adjust theme handling to avoid dark blank area

## Testing
- `python -m py_compile $(git ls-files '*.py')`
