### PR TITLE
Add Steam play/install popup for liked game

### DIFF
--- a/domain/use_cases.py
+++ b/domain/use_cases.py
@@ -1,16 +1,24 @@
 import random
+from typing import Callable, Tuple
 from data.activity_dao import ActivityDAO
 
 dao = ActivityDAO()
 
 
-def _build_weighted_items():
-    """Return hobby items alongside their selection weights."""
+def _build_weighted_items(
+    filter_func: Callable[[Tuple[int, str, bool, int]], bool] | None = None,
+):
+    """Return hobby items alongside their selection weights.
+
+    The optional *filter_func* receives tuples of
+    ``(item_id, label, is_subitem, accepted_count)`` and should return ``True``
+    to keep the item in the result.
+    """
     activities = dao.get_all_with_counts()
     if not activities:
         return [], []
 
-    temp_items = []
+    temp_items: list[Tuple[int, str, bool, int]] = []
     for hobby_id, name, act_count in activities:
         subitems = dao.get_subitems_by_activity(hobby_id)
         if subitems:
@@ -23,14 +31,30 @@ def _build_weighted_items():
     items: list[tuple[int, str, bool]] = []
     weights: list[int] = []
     for item_id, label, is_sub, count in temp_items:
+        if filter_func and not filter_func((item_id, label, is_sub, count)):
+            continue
         weight = max_count - count
         items.append((item_id, label, is_sub))
         weights.append(weight)
     return items, weights
 
 
-def get_weighted_random_valid_activity():
-    items, weights = _build_weighted_items()
+def build_weighted_items(
+    filter_func: Callable[[Tuple[int, str, bool, int]], bool] | None = None,
+):
+    """Public wrapper to obtain weighted item lists.
+
+    Exposes the internal `_build_weighted_items` so callers can cache the
+    resulting `(items, weights)` tuples and reuse them without hitting the
+    database repeatedly.
+    """
+    return _build_weighted_items(filter_func)
+
+
+def get_weighted_random_valid_activity(
+    filter_func: Callable[[Tuple[int, str, bool, int]], bool] | None = None,
+):
+    items, weights = _build_weighted_items(filter_func)
     if not items:
         return None
     return random.choices(items, weights=weights, k=1)[0]
@@ -63,8 +87,10 @@ def update_subitem(subitem_id, new_name):
     dao.update_subitem(subitem_id, new_name)
 
 
-def get_activity_probabilities():
-    items, weights = _build_weighted_items()
+def get_activity_probabilities(
+    filter_func: Callable[[Tuple[int, str, bool, int]], bool] | None = None,
+):
+    items, weights = _build_weighted_items(filter_func)
     if not items:
         return []
 

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -448,6 +448,10 @@ def start_app() -> None:
             include_games_switch.redraw()
         if games_only_switch is not None:
             games_only_switch.redraw()
+        if include_games_label is not None:
+            include_games_label.config(foreground=get_color("contrast"))
+        if games_only_label is not None:
+            games_only_label.config(foreground=get_color("contrast"))
         if refresh_probabilities:
             refresh_probabilities()
         save_settings()
@@ -491,9 +495,13 @@ def start_app() -> None:
         prob_table.heading("percent", text=tr("col_percent"))
         rebuild_menus()
         if include_games_label is not None:
-            include_games_label.config(text=tr("include_games"))
+            include_games_label.config(
+                text=tr("include_games"), foreground=get_color("contrast")
+            )
         if games_only_label is not None:
-            games_only_label.config(text=tr("games_only"))
+            games_only_label.config(
+                text=tr("games_only"), foreground=get_color("contrast")
+            )
         if final_canvas is not None and overlay_buttons:
             final_canvas.itemconfigure(
                 "final_text", text=tr("what_about").format(current_activity["name"])
@@ -581,7 +589,10 @@ def start_app() -> None:
     include_row = ttk.Frame(toggle_container, style="Surface.TFrame")
     include_row.pack(anchor="e", pady=2)
     include_games_label = ttk.Label(
-        include_row, text=tr("include_games"), style="Surface.TLabel"
+        include_row,
+        text=tr("include_games"),
+        style="Surface.TLabel",
+        foreground=get_color("contrast"),
     )
     include_games_label.pack(side="left", padx=(0, 5))
     include_games_switch = ToggleSwitch(
@@ -592,7 +603,10 @@ def start_app() -> None:
     only_row = ttk.Frame(toggle_container, style="Surface.TFrame")
     only_row.pack(anchor="e", pady=2)
     games_only_label = ttk.Label(
-        only_row, text=tr("games_only"), style="Surface.TLabel"
+        only_row,
+        text=tr("games_only"),
+        style="Surface.TLabel",
+        foreground=get_color("contrast"),
     )
     games_only_label.pack(side="left", padx=(0, 5))
     games_only_switch = ToggleSwitch(
@@ -636,6 +650,7 @@ def start_app() -> None:
         suggest_btn.state(["!disabled"])
         suggestion_label.config(text=tr("prompt"))
         suggestion_label.pack(pady=20, expand=True)
+        toggle_container.place(relx=1.0, rely=0.0, anchor="ne", x=-10, y=10)
         final_timeout_id = None
 
     def show_final_activity(text: str) -> None:
@@ -726,6 +741,7 @@ def start_app() -> None:
         for btn, _ in overlay_buttons:
             btn.state(["disabled"])
         suggest_btn.state(["disabled"])
+        toggle_container.place_forget()
         if final_timeout_id is not None:
             root.after_cancel(final_timeout_id)
             final_timeout_id = None
@@ -744,6 +760,7 @@ def start_app() -> None:
                 text=tr("no_hobbies")
             )
             suggestion_label.pack(pady=20, expand=True)
+            toggle_container.place(relx=1.0, rely=0.0, anchor="ne", x=-10, y=10)
             return
 
         final_id, final_text, is_sub = result
@@ -843,6 +860,7 @@ def start_app() -> None:
             current_activity["is_subitem"] = False
             suggestion_label.config(text=tr("prompt"))
             suggestion_label.pack(pady=20, expand=True)
+            toggle_container.place(relx=1.0, rely=0.0, anchor="ne", x=-10, y=10)
             if final_timeout_id is not None:
                 root.after_cancel(final_timeout_id)
                 final_timeout_id = None

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -364,12 +364,13 @@ def start_app() -> None:
         dlg.title("Steam")
         dlg.transient(root)
         dlg.grab_set()
-        WindowUtils.center_window(dlg, 300, 130)
+        WindowUtils.center_window(dlg, 600, 130)
         ttk.Label(
             dlg,
             text=tr("steam_action_prompt").format(name=game_name),
             justify="center",
             anchor="center",
+            wraplength=560,
         ).pack(padx=20, pady=15)
 
         def act() -> None:

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -18,6 +18,7 @@ from domain import use_cases
 from presentation.widgets.styles import apply_style, get_color, add_button_hover
 from presentation.utils.window_utils import WindowUtils
 from presentation.widgets.simple_entry_dialog import SimpleEntryDialog
+from presentation.widgets.toggle_switch import ToggleSwitch
 
 
 
@@ -50,6 +51,11 @@ def start_app() -> None:
 
     include_games_var = tk.BooleanVar(value=True)
     games_only_var = tk.BooleanVar(value=False)
+
+    include_games_switch = None  # switch for including games
+    games_only_switch = None  # switch for installed games only
+    include_games_label = None
+    games_only_label = None
 
     refresh_probabilities = None  # placeholder, defined after table creation
 
@@ -421,8 +427,6 @@ def start_app() -> None:
     button_container = None  # contenedor de botones inferior
     overlay_buttons = []  # referencias a botones del overlay
     final_timeout_id = None
-    games_check = None  # toggle de incluir juegos
-    games_only_check = None  # toggle de solo juegos
 
     # --- Notebook principal ---
     notebook = ttk.Notebook(root)
@@ -439,6 +443,10 @@ def start_app() -> None:
         if final_canvas is not None:
             final_canvas.configure(bg=get_color("surface"))
             final_canvas.itemconfigure("final_text", fill=get_color("text"))
+        if include_games_switch is not None:
+            include_games_switch.redraw()
+        if games_only_switch is not None:
+            games_only_switch.redraw()
         if refresh_probabilities:
             refresh_probabilities()
         save_settings()
@@ -481,10 +489,10 @@ def start_app() -> None:
         prob_table.heading("activity", text=tr("col_activity"))
         prob_table.heading("percent", text=tr("col_percent"))
         rebuild_menus()
-        if games_check is not None:
-            games_check.config(text=tr("include_games"))
-        if games_only_check is not None:
-            games_only_check.config(text=tr("games_only"))
+        if include_games_label is not None:
+            include_games_label.config(text=tr("include_games"))
+        if games_only_label is not None:
+            games_only_label.config(text=tr("games_only"))
         if final_canvas is not None and overlay_buttons:
             final_canvas.itemconfigure(
                 "final_text", text=tr("what_about").format(current_activity["name"])
@@ -554,17 +562,44 @@ def start_app() -> None:
     refresh_probabilities()
 
     def on_toggle_update():
-        nonlocal games_only_check
+        nonlocal games_only_switch
         if games_only_var.get():
             include_games_var.set(True)
         if not include_games_var.get():
             games_only_var.set(False)
-            if games_only_check is not None:
-                games_only_check.state(["disabled"])
+            if games_only_switch is not None:
+                games_only_switch.state(["disabled"])
         else:
-            if games_only_check is not None:
-                games_only_check.state(["!disabled"])
+            if games_only_switch is not None:
+                games_only_switch.state(["!disabled"])
         refresh_probabilities()
+
+    toggle_container = ttk.Frame(content_frame, style="Surface.TFrame")
+    toggle_container.place(relx=1.0, rely=0.0, anchor="ne", x=-10, y=10)
+
+    include_row = ttk.Frame(toggle_container, style="Surface.TFrame")
+    include_row.pack(anchor="e", pady=2)
+    include_games_label = ttk.Label(
+        include_row, text=tr("include_games"), style="Surface.TLabel"
+    )
+    include_games_label.pack(side="left", padx=(0, 5))
+    include_games_switch = ToggleSwitch(
+        include_row, variable=include_games_var, command=on_toggle_update
+    )
+    include_games_switch.pack(side="left")
+
+    only_row = ttk.Frame(toggle_container, style="Surface.TFrame")
+    only_row.pack(anchor="e", pady=2)
+    games_only_label = ttk.Label(
+        only_row, text=tr("games_only"), style="Surface.TLabel"
+    )
+    games_only_label.pack(side="left", padx=(0, 5))
+    games_only_switch = ToggleSwitch(
+        only_row, variable=games_only_var, command=on_toggle_update
+    )
+    games_only_switch.pack(side="left")
+
+    on_toggle_update()
 
     suggestion_label = ttk.Label(
         content_frame,
@@ -844,27 +879,6 @@ def start_app() -> None:
 
     button_container = ttk.Frame(content_frame, style="Surface.TFrame")
     button_container.pack(side="bottom", fill="x", pady=20)
-
-    toggle_frame = ttk.Frame(button_container, style="Surface.TFrame")
-    toggle_frame.pack(pady=(0, 10))
-
-    games_check = ttk.Checkbutton(
-        toggle_frame,
-        text=tr("include_games"),
-        variable=include_games_var,
-        command=on_toggle_update,
-    )
-    games_check.pack(side="left", padx=5)
-
-    games_only_check = ttk.Checkbutton(
-        toggle_frame,
-        text=tr("games_only"),
-        variable=games_only_var,
-        command=on_toggle_update,
-    )
-    games_only_check.pack(side="left", padx=5)
-
-    on_toggle_update()
 
     suggest_btn = ttk.Button(
         button_container,

--- a/presentation/app.py
+++ b/presentation/app.py
@@ -1,16 +1,18 @@
 import json
 import locale
+import os
 import random
 import threading
 import webbrowser
+import re
 from http.server import HTTPServer, BaseHTTPRequestHandler
-from urllib.parse import urlencode, urlparse, parse_qs
+from urllib.parse import urlencode, urlparse, parse_qs, quote
 from pathlib import Path
 import xml.etree.ElementTree as ET
 import requests
 import tkinter as tk
 from tkinter import messagebox, ttk
-from functools import partial
+from functools import partial, lru_cache
 
 from domain import use_cases
 from presentation.widgets.styles import apply_style, get_color, add_button_hover
@@ -46,6 +48,8 @@ def start_app() -> None:
     lang_var = tk.StringVar(value=settings["language"])
     theme_var = tk.StringVar(value=settings["theme"])
 
+    include_games_var = tk.BooleanVar(value=True)
+    installed_only_var = tk.BooleanVar(value=False)
 
     refresh_probabilities = None  # placeholder, defined after table creation
 
@@ -106,6 +110,12 @@ def start_app() -> None:
             "steam_import_success": "Se importaron {count} juegos.",
             "steam_import_error": "No se pudo importar los juegos.",
             "steam_hobby_name": "Jugar",
+            "steam_action_prompt": "¿Qué quieres hacer con '{name}'?",
+            "steam_play": "Jugar juego",
+            "steam_install": "Instalar juego",
+            "steam_not_found": "No se encontró el juego en Steam.",
+            "include_games": "Incluir juegos",
+            "only_installed": "Solo juegos instalados",
         },
         "en": {
             "tab_today": "What should I do today?",
@@ -153,6 +163,12 @@ def start_app() -> None:
             "steam_import_success": "Imported {count} games.",
             "steam_import_error": "Could not import games.",
             "steam_hobby_name": "Play",
+            "steam_action_prompt": "What do you want to do with '{name}'?",
+            "steam_play": "Play game",
+            "steam_install": "Install game",
+            "steam_not_found": "Could not find the game on Steam.",
+            "include_games": "Include games",
+            "only_installed": "Installed only",
         },
     }
 
@@ -165,6 +181,14 @@ def start_app() -> None:
 
     def tr(key: str) -> str:
         return LANG_TEXT[get_effective_language()][key]
+
+    STEAM_HOBBY_NAMES = {
+        LANG_TEXT["es"]["steam_hobby_name"],
+        LANG_TEXT["en"]["steam_hobby_name"],
+    }
+
+    def is_steam_game_label(label: str) -> bool:
+        return any(label.startswith(name + " + ") for name in STEAM_HOBBY_NAMES)
 
     def login_steam_id() -> str | None:
         result = {"id": None}
@@ -229,12 +253,169 @@ def start_app() -> None:
             new_games = [g for g in games if g not in all_existing]
             for name in new_games:
                 use_cases.add_subitem_to_hobby(hobby_id, name)
+            build_activity_caches()
             refresh_listbox()
-            if refresh_probabilities:
-                refresh_probabilities()
             messagebox.showinfo("Steam", tr("steam_import_success").format(count=len(new_games)))
         except Exception:
             messagebox.showerror(tr("error"), tr("steam_import_error"))
+
+    @lru_cache(maxsize=None)
+    def get_steam_appid(game_name: str) -> int | None:
+        try:
+            resp = requests.get(
+                "https://steamcommunity.com/actions/SearchApps/" + quote(game_name),
+                timeout=5,
+            )
+            data = resp.json()
+            return int(data[0]["appid"]) if data else None
+        except Exception:
+            return None
+
+    @lru_cache(maxsize=1)
+    def discover_steam_libraries() -> list[Path]:
+        paths: list[Path] = []
+        candidate_roots: list[Path] = []
+        if os.name == "nt":
+            pf_x86 = os.environ.get("PROGRAMFILES(X86)")
+            pf = os.environ.get("PROGRAMFILES")
+            if pf_x86:
+                candidate_roots.append(Path(pf_x86) / "Steam")
+            if pf:
+                candidate_roots.append(Path(pf) / "Steam")
+            for letter in "CDEFGHIJKLMNOPQRSTUVWXYZ":
+                base = Path(f"{letter}:/")
+                candidate_roots.extend(
+                    [
+                        base / "Steam",
+                        base / "SteamLibrary",
+                        base / "Program Files/Steam",
+                        base / "Program Files (x86)/Steam",
+                    ]
+                )
+        else:
+            candidate_roots.extend(
+                [
+                    Path.home() / ".steam/steam",
+                    Path.home() / ".local/share/Steam",
+                    Path.home() / "Library/Application Support/Steam",
+                ]
+            )
+        for root in candidate_roots:
+            steamapps = root / "steamapps"
+            if steamapps.exists():
+                paths.append(steamapps)
+                vdf = steamapps / "libraryfolders.vdf"
+                if vdf.exists():
+                    try:
+                        text = vdf.read_text(encoding="utf-8", errors="ignore")
+                        for folder in re.findall(r'"path"\s*"([^"]+)"', text):
+                            lib_path = Path(folder).expanduser()
+                            candidate = lib_path / "steamapps"
+                            if candidate.exists():
+                                paths.append(candidate)
+                    except Exception:
+                        pass
+        unique: list[Path] = []
+        for p in paths:
+            resolved = p.resolve()
+            if resolved not in unique:
+                unique.append(resolved)
+        return unique
+
+    def _normalize_game_name(name: str) -> str:
+        return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+    @lru_cache(maxsize=1)
+    def load_installed_games() -> dict[str, int]:
+        games: dict[str, int] = {}
+        for path in discover_steam_libraries():
+            for manifest in path.glob("appmanifest_*.acf"):
+                try:
+                    text = manifest.read_text(encoding="utf-8", errors="ignore")
+                    appid_match = re.search(r'"appid"\s*"(\d+)"', text)
+                    name_match = re.search(r'"name"\s*"([^\"]+)"', text)
+                    if appid_match and name_match:
+                        games[_normalize_game_name(name_match.group(1))] = int(
+                            appid_match.group(1)
+                        )
+                except Exception:
+                    pass
+        return games
+
+    def get_local_appid(game_name: str) -> int | None:
+        return load_installed_games().get(_normalize_game_name(game_name))
+
+    def show_game_popup(game_name: str) -> None:
+        appid = get_local_appid(game_name)
+        installed = appid is not None
+        if not installed:
+            appid = get_steam_appid(game_name)
+        if not appid:
+            messagebox.showerror("Steam", tr("steam_not_found"))
+            return
+        dlg = tk.Toplevel(root)
+        apply_style(dlg)
+        dlg.title("Steam")
+        dlg.transient(root)
+        dlg.grab_set()
+        WindowUtils.center_window(dlg, 300, 130)
+        ttk.Label(
+            dlg,
+            text=tr("steam_action_prompt").format(name=game_name),
+            justify="center",
+            anchor="center",
+        ).pack(padx=20, pady=15)
+
+        def act() -> None:
+            url = (
+                f"steam://rungameid/{appid}"
+                if installed
+                else f"steam://install/{appid}"
+            )
+            webbrowser.open(url)
+            dlg.destroy()
+
+        btn = ttk.Button(
+            dlg,
+            text=tr("steam_play") if installed else tr("steam_install"),
+            command=act,
+            width=20,
+        )
+        btn.pack(pady=(0, 15))
+        add_button_hover(btn)
+    activity_lists = {}
+
+    def build_activity_caches() -> None:
+        """Cache weighted activity lists for quick toggle switches."""
+        discover_steam_libraries.cache_clear()
+        load_installed_games.cache_clear()
+        discover_steam_libraries()
+        load_installed_games()
+        def filter_no_games(item):
+            _, label, is_sub, _ = item
+            return not (is_sub and is_steam_game_label(label))
+
+        def filter_installed(item):
+            _, label, is_sub, _ = item
+            if not (is_sub and is_steam_game_label(label)):
+                return True
+            game_name = label.split(" + ", 1)[1]
+            return get_local_appid(game_name) is not None
+
+        activity_lists["all"] = use_cases.build_weighted_items()
+        activity_lists["no_games"] = use_cases.build_weighted_items(filter_no_games)
+        activity_lists["installed"] = use_cases.build_weighted_items(filter_installed)
+        if refresh_probabilities:
+            refresh_probabilities()
+
+    build_activity_caches()
+
+    def current_items_weights():
+        if not include_games_var.get():
+            return activity_lists["no_games"]
+        if installed_only_var.get():
+            return activity_lists["installed"]
+        return activity_lists["all"]
 
     canvas = None  # se asigna más tarde
     separator = None  # línea divisoria asignada después
@@ -243,6 +424,8 @@ def start_app() -> None:
     button_container = None  # contenedor de botones inferior
     overlay_buttons = []  # referencias a botones del overlay
     final_timeout_id = None
+    games_check = None  # toggle de incluir juegos
+    installed_check = None  # toggle de solo instalados
 
     # --- Notebook principal ---
     notebook = ttk.Notebook(root)
@@ -301,6 +484,10 @@ def start_app() -> None:
         prob_table.heading("activity", text=tr("col_activity"))
         prob_table.heading("percent", text=tr("col_percent"))
         rebuild_menus()
+        if games_check is not None:
+            games_check.config(text=tr("include_games"))
+        if installed_check is not None:
+            installed_check.config(text=tr("only_installed"))
         if final_canvas is not None and overlay_buttons:
             final_canvas.itemconfigure(
                 "final_text", text=tr("what_about").format(current_activity["name"])
@@ -358,11 +545,27 @@ def start_app() -> None:
         prob_table.tag_configure(
             "odd", background=get_color("light"), foreground=get_color("text")
         )
-        for i, (name, prob) in enumerate(use_cases.get_activity_probabilities()):
+        items, weights = current_items_weights()
+        if not items:
+            return
+        total_weight = sum(weights)
+        for i, ((_, name, _), weight) in enumerate(zip(items, weights)):
             tag = "even" if i % 2 == 0 else "odd"
+            prob = weight / total_weight
             prob_table.insert("", "end", values=(name, f"{prob*100:.1f}%"), tags=(tag,))
 
     refresh_probabilities()
+
+    def on_toggle_update():
+        nonlocal installed_check
+        if not include_games_var.get():
+            installed_only_var.set(False)
+            if installed_check is not None:
+                installed_check.state(["disabled"])
+        else:
+            if installed_check is not None:
+                installed_check.state(["!disabled"])
+        refresh_probabilities()
 
     suggestion_label = ttk.Label(
         content_frame,
@@ -499,7 +702,8 @@ def start_app() -> None:
             if table_frame is not None:
                 table_frame.grid()
             button_container.pack(side="bottom", fill="x", pady=20)
-        result = use_cases.get_weighted_random_valid_activity()
+        items, weights = current_items_weights()
+        result = random.choices(items, weights=weights, k=1)[0] if items else None
         if not result:
             suggestion_label.config(
                 text=tr("no_hobbies")
@@ -514,8 +718,8 @@ def start_app() -> None:
 
         options = []
         for _ in range(20):
-            alt = use_cases.get_weighted_random_valid_activity()
-            if alt:
+            if items:
+                alt = random.choices(items, weights=weights, k=1)[0]
                 options.append(alt[1])
         options += [final_text, ""]
 
@@ -583,9 +787,22 @@ def start_app() -> None:
     def accept():
         nonlocal final_canvas, final_timeout_id
         if current_activity["id"]:
+            is_game = (
+                current_activity["is_subitem"]
+                and current_activity["name"]
+                and is_steam_game_label(current_activity["name"])
+            )
+            game_name = (
+                current_activity["name"].split(" + ", 1)[1]
+                if is_game
+                else ""
+            )
             use_cases.mark_activity_as_done(
                 current_activity["id"], current_activity["is_subitem"]
             )
+            build_activity_caches()
+            if is_game:
+                show_game_popup(game_name)
             current_activity["id"] = None
             current_activity["name"] = None
             current_activity["is_subitem"] = False
@@ -628,6 +845,27 @@ def start_app() -> None:
 
     button_container = ttk.Frame(content_frame, style="Surface.TFrame")
     button_container.pack(side="bottom", fill="x", pady=20)
+
+    toggle_frame = ttk.Frame(button_container, style="Surface.TFrame")
+    toggle_frame.pack(pady=(0, 10))
+
+    games_check = ttk.Checkbutton(
+        toggle_frame,
+        text=tr("include_games"),
+        variable=include_games_var,
+        command=on_toggle_update,
+    )
+    games_check.pack(side="left", padx=5)
+
+    installed_check = ttk.Checkbutton(
+        toggle_frame,
+        text=tr("only_installed"),
+        variable=installed_only_var,
+        command=on_toggle_update,
+    )
+    installed_check.pack(side="left", padx=5)
+
+    on_toggle_update()
 
     suggest_btn = ttk.Button(
         button_container,
@@ -725,6 +963,7 @@ def start_app() -> None:
         ):
             use_cases.delete_hobby(hobby_id)
             refresh_listbox()
+            build_activity_caches()
             messagebox.showinfo(tr("deleted"), tr("hobby_deleted").format(name=hobby_name))
 
     def open_edit_hobby_window(hobby_id, hobby_name):
@@ -760,6 +999,7 @@ def start_app() -> None:
                     if new_name and new_name.strip() != current_name:
                         use_cases.update_subitem(subitem_id, new_name.strip())
                         refresh_items()
+                        build_activity_caches()
 
                 ttk.Button(
                     row,
@@ -777,6 +1017,7 @@ def start_app() -> None:
             ):
                 use_cases.delete_subitem(item_id)
                 refresh_items()
+                build_activity_caches()
 
         def add_subitem():
             new_item = SimpleEntryDialog.ask(
@@ -787,6 +1028,7 @@ def start_app() -> None:
             if new_item:
                 use_cases.add_subitem_to_hobby(hobby_id, new_item.strip())
                 refresh_items()
+                build_activity_caches()
 
         ttk.Button(
             edit_window, text=tr("add_subitem_btn"), command=add_subitem
@@ -810,6 +1052,7 @@ def start_app() -> None:
                     title=tr("another_title"),
                     prompt=tr("another_prompt"),
                 )
+            build_activity_caches()
             add_window.destroy()
             refresh_listbox()
 

--- a/presentation/widgets/styles.py
+++ b/presentation/widgets/styles.py
@@ -177,6 +177,11 @@ def apply_style(master: ttk.Widget | None = None, theme: str | None = None) -> N
 
     style.configure("TRadiobutton", background=background, padding=5)
     style.configure("TCheckbutton", background=background, padding=5)
+    style.map(
+        "TCheckbutton",
+        background=[("disabled", background)],
+        foreground=[("disabled", text)],
+    )
 
     scroll_conf = dict(
         gripcount=0,

--- a/presentation/widgets/toggle_switch.py
+++ b/presentation/widgets/toggle_switch.py
@@ -40,7 +40,7 @@ class ToggleSwitch(ttk.Frame):
         c = self.canvas
         c.delete("all")
         c.configure(bg=get_color("surface"))
-        track = get_color("subtle")
+        track = get_color("contrast")
         if self.variable.get():
             track = get_color("primary")
         if self._disabled:

--- a/presentation/widgets/toggle_switch.py
+++ b/presentation/widgets/toggle_switch.py
@@ -40,7 +40,7 @@ class ToggleSwitch(ttk.Frame):
         c = self.canvas
         c.delete("all")
         c.configure(bg=get_color("surface"))
-        track = get_color("light")
+        track = get_color("subtle")
         if self.variable.get():
             track = get_color("primary")
         if self._disabled:
@@ -50,6 +50,8 @@ class ToggleSwitch(ttk.Frame):
         c.create_oval(4, 6, 20, 22, fill=track, outline=track)
         c.create_oval(20, 6, 36, 22, fill=track, outline=track)
         # knob
-        knob_color = get_color("surface") if not self._disabled else get_color("subtle")
+        knob_color = (
+            get_color("surface") if not self._disabled else get_color("light")
+        )
         knob_x = 20 if self.variable.get() else 4
         c.create_oval(knob_x, 6, knob_x + 16, 22, fill=knob_color, outline=knob_color)

--- a/presentation/widgets/toggle_switch.py
+++ b/presentation/widgets/toggle_switch.py
@@ -1,0 +1,55 @@
+import tkinter as tk
+from tkinter import ttk
+
+from .styles import get_color
+
+
+class ToggleSwitch(ttk.Frame):
+    """A small on/off switch drawn on a canvas."""
+
+    def __init__(self, master=None, variable=None, command=None, **kwargs):
+        super().__init__(master, style="Surface.TFrame", **kwargs)
+        self.variable = variable or tk.BooleanVar(value=False)
+        self.command = command
+        self._disabled = False
+        self.canvas = tk.Canvas(
+            self, width=40, height=24, highlightthickness=0, bg=get_color("surface")
+        )
+        self.canvas.pack()
+        self.canvas.bind("<Button-1>", self._toggle)
+        self.variable.trace_add("write", lambda *_: self.redraw())
+        self.redraw()
+
+    def _toggle(self, _event=None):
+        if self._disabled:
+            return
+        self.variable.set(not self.variable.get())
+        if self.command:
+            self.command()
+
+    def state(self, states=None):  # minimal ttk-like interface
+        if states is None:
+            return ["disabled"] if self._disabled else ["!disabled"]
+        if "disabled" in states:
+            self._disabled = True
+        if "!disabled" in states:
+            self._disabled = False
+        self.redraw()
+
+    def redraw(self):
+        c = self.canvas
+        c.delete("all")
+        c.configure(bg=get_color("surface"))
+        track = get_color("light")
+        if self.variable.get():
+            track = get_color("primary")
+        if self._disabled:
+            track = get_color("light")
+        # draw track (rounded rectangle)
+        c.create_rectangle(12, 6, 28, 18, fill=track, outline=track)
+        c.create_oval(4, 6, 20, 22, fill=track, outline=track)
+        c.create_oval(20, 6, 36, 22, fill=track, outline=track)
+        # knob
+        knob_color = get_color("surface") if not self._disabled else get_color("subtle")
+        knob_x = 20 if self.variable.get() else 4
+        c.create_oval(knob_x, 6, knob_x + 16, 22, fill=knob_color, outline=knob_color)


### PR DESCRIPTION
## Summary
- parse Steam manifests to map installed game names to app IDs
- rebuild activity caches after hobby edits and Steam imports to keep lists current
- use local app IDs to drive "installed only" filtering and Steam popup actions
- detect Steam hobby items in any supported language so installed-game lists show correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a79b8a3a448333939478607306be4d